### PR TITLE
Global aggiornato con formato  post-candidatura

### DIFF
--- a/sources/documents/RTB/Verbali/Interni/VerbaleInterno_2024-04-03/registro_modifiche.tex
+++ b/sources/documents/RTB/Verbali/Interni/VerbaleInterno_2024-04-03/registro_modifiche.tex
@@ -3,9 +3,9 @@
 \bgroup
 \begin{adjustwidth}{-0.5cm}{-0.5cm}
 	% MAX 12.5cm
- 	\begin{longtable}{|P{1.7cm}|P{2.2cm}|P{2.5cm}|P{2.5cm}|>{\arraybackslash}P{3.6cm}|}
+ 	\begin{longtable}{|P{1cm}|P{2.2cm}|P{2.7cm}|P{2.7cm}|>{\arraybackslash}P{3.8cm}|}
 	  \hline
-		\textbf{Versione} & \textbf{Data} & \textbf{Autori/Autrici} & \textbf{Ruolo} & \textbf{Descrizione} \\ 
+		\textbf{Ver.} & \textbf{Data} & \textbf{Redazione} & \textbf{Verifica} & \textbf{Descrizione} \\ 
 		\hline
 		\endfirsthead
 
@@ -24,9 +24,7 @@
 
 		% IN ORDINE DALLA MODIFICA PIÙ RECENTE ALLA PIÙ VECCHIA
 
-	 	1.0.0 & 2024-04-03 & \sebastiano & \Responsabile & Approvazione \\
-		\hline 0.1.0 & 2024-04-03 & \marco & \Verificatore & Revisione completa \\
-		\hline 0.0.1 & 2024-04-03 & \riccardo & \Redattore & Stesura del documento \\
+		\hline 0.0.1 & 2024-04-03 & \riccardo & \raul & Stesura del documento \\
 	\end{longtable}
 \end{adjustwidth}
 \egroup

--- a/sources/model/global.tex
+++ b/sources/model/global.tex
@@ -3,6 +3,7 @@
 %%%%%%%%%%%%%%
 
 % In questa prima parte vanno definite le 'costanti' utilizzate da due o più documenti.
+
 % Serve a dare la giusta formattazione alle parole presenti nel glossario
 % il nome del comando \glossary è già usato da LaTeX
 % permette di distingure la prima occorrenza della parola nel documento
@@ -22,23 +23,33 @@
 % Meglio non mettere gli \emph dentro le costanti, in certi casi creano problemi
 \newcommand{\GroupName}{Argo}
 \newcommand{\GroupEmail}{argo.unipd@gmail.com}
-\newcommand{\ProjectName}{}
+\newcommand{\ProjectName}{ChatSQL}
 \newcommand{\ProjectVersion}{}
 
 \newcommand{\DemoName}{DEMO_NAME}
 
-\newcommand{\Proponente}{}
+\newcommand{\Proponente}{Zucchetti S.p.A.}
 \newcommand{\Committente}{Prof. Tullio Vardanega \\ Prof. Riccardo Cardin}
 \newcommand{\CommittenteInline}{Prof. Tullio Vardanega, Prof. Riccardo Cardin}
 \newcommand{\ResponsabileInCarica}{\sebastiano}
 
 % La versione dei documenti deve essere definita qui in global, perchè serve anche agli altri documenti
+\newcommand{\VersionePP}{0.0.1}  % Piano di Progetto
+\newcommand{\VersioneNP}{0.0.1}  % Norme di Progetto
+\newcommand{\VersioneAR}{0.0.1}  % Analisi dei Requisiti
+\newcommand{\VersioneG}{0.0.1}   % Glossario
 
 % Il verbale non ha versionamento.
 % Lasciare vuoto, non mettere trattini o puntini
 % Non sono permessi numeri nel nome di un comando :(
 \newcommand{\VersioneVprimo}{}
 \newcommand{\VersioneVsecondo}{}
+
+% Per riferirsi ad alti documenti globalmente, se la versione nella parte soprastante è vuota il numero non compare
+\newcommand{\PianoDiProgetto}{\emph{Piano di Progetto v\VersionePP{}}}
+\newcommand{\NormeDiProgetto}{\emph{Norme di Progetto v\VersioneNP{}}}
+\newcommand{\AnalisideiRequisiti}{\emph{Analisi dei Requisiti v\VersioneAR{}}}
+\newcommand{\Glossario}{\emph{Glossario v\VersioneG{}}}
 
 % Per riferirsi alle revisioni usare i comandi seguenti:
 \newcommand{\RTB}{Requirements and Technology Baseline}
@@ -80,6 +91,11 @@
 \newcommand{\ScopoDelProdotto}{}
 
 \newcommand{\ScopoDelProdottoEng}{}
+
+\newcommand{\GlossarioIntroduzione}{
+  Insieme al progetto il gruppo fornisce un glossario nel quale sono raccolti i termini tecnici, gli acronimi e le parole che richiedono chiarimenti utilizzate nella documentazione.\\
+  I vocaboli presenti nel \Glossario{} sono marcati alla loro prima occorrenza nel documento con una \textit{\small{G}} al pedice. \\
+}
 
 \newcommand{\ToBeContinued}{\textit{Continua nella prossima pagina}}
 
@@ -137,7 +153,7 @@
   \textbf{\DocTitle{}}
   \end{Huge}
 
-  \textbf{\emph{Gruppo \GroupName{}}}
+  \textbf{\emph{Gruppo \GroupName{} \, \texttwelveudash{} \, Progetto \ProjectName{}}}
 
   \vspace{10pt}
 


### PR DESCRIPTION
Ora sono presenti i comandi per riferirsi alla documentazione su cui il gruppo sta lavorando al momento (Analisi dei Requisiti, Piano di Progetto, Norme di Progetto, Glossario).
Il comando \glossario{ ... }, già presente nel template all'inizio del file global.tex, permette di marcare l'argomento del comando come appartentente al glossario (aggiungengo una G in pedice). Qualora in un documento ci siano più occorrenze della formula _\glossario{argomento}_ , nel documento generato solo la prima occorrenza sarà marcata (ciò permette la ridondanza di uso del comando senza una ripercussione sulla leggibilità).