### PR TITLE
corretto comando avvio per rimuovere warning

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,10 +1,9 @@
-version: "3.8"
 name: argo-docs
 
 services:
   latexpdfbuilder:
     build: ./docker
-    command: tail -F anything
+    command: tail -F /dev/null
     environment:
       - TEXINPUTS=/data/sources/model//:${TEXINPUTS}
     volumes:


### PR DESCRIPTION
rimosso avviso all'avvio di docker 
`tail: cannot open 'anything' for reading...`